### PR TITLE
Added benchmark for select the first element matching in an Enumerable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,22 @@ Comparison:
      Enumerable#sort:    12892.0 i/s - 2.13x slower
 ```
 
+##### `Enumerable#detect` vs `Enumerable#select.first` [code](code/enumerable/select-first-vs-detect.rb)
+
+```
+$ ruby 2.2.0p0 (2014-12-25 revision 49005) [x86_64-darwin14]
+Calculating -------------------------------------
+Enumerable#select.first    9.265k i/100ms
+      Enumerable#detect    37.176k i/100ms
+-------------------------------------------------
+Enumerable#select.first    94.906k (± 6.4%) i/s -      1.890M
+      Enumerable#detect    461.291k (± 4.9%) i/s -      9.220M
+
+Comparison:
+      Enumerable#detect:    461291.4 i/s
+Enumerable#select.first:    94906.2 i/s - 4.86x slower
+```
+
 ### Hash
 
 ##### `Hash#merge` vs `Hash#merge!` [code](code/hash/merge-vs-merge-bang.rb)

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Comparison:
   Array#reverse.each:   205046.1 i/s - 1.13x slower
 ```
 
-##### `Enumerable#each` vs `Enumerable#map + push` [code](code/enumerable/each-push-vs-map.rb)
+##### `Enumerable#each + push` vs `Enumerable#map` [code](code/enumerable/each-push-vs-map.rb)
 
 ```
 $ ruby -v code/enumerable/each-push-vs-map.rb

--- a/code/enumerable/select-first-vs-detect.rb
+++ b/code/enumerable/select-first-vs-detect.rb
@@ -1,0 +1,17 @@
+require 'benchmark/ips'
+
+ARRAY = [*1..100]
+
+def slow
+  ARRAY.select { |x| x.eql?(15) }.first
+end
+
+def fast
+  ARRAY.detect { |x| x.eql?(15) }
+end
+
+Benchmark.ips(20) do |x|
+  x.report('Enumerable#select.first') { slow }
+  x.report('Enumerable#detect') { fast }
+  x.compare!
+end


### PR DESCRIPTION
Hi, I figured out that some people use the wrong way to select the first element of an Enumerable that match to _x_.
I wrote a test case that represent the performance issue when using the wrong way.

Bonus : I fixed a test case title in the readme.