### PR TITLE
Adding Array#reverse.index vs Array#size - Array#index - 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,23 @@ Comparison:
  Array#shuffle.first:   304341.1 i/s - 18.82x slower
 ```
 
+##### `Array#reverse.index` vs `Array#size - Array#index - 1` [code](code/array/reverse-index-vs-size.rb)
+
+```
+$ ruby -v code/array/reverse-index-vs-size.rb
+ruby 2.1.5p273 (2014-11-13 revision 48405) [x86_64-darwin14.0]
+
+Calculating -------------------------------------
+     reverse + index    14.587k i/100ms
+    size - index - 1    97.213k i/100ms
+-------------------------------------------------
+     reverse + index    160.685k (± 6.5%) i/s -    802.285k
+    size - index - 1      2.370M (± 9.6%) i/s -     11.763M
+
+Comparison:
+    size - index - 1:  2370032.0 i/s
+     reverse + index:   160685.2 i/s - 14.75x slower
+```
 
 ### Enumerable
 

--- a/code/array/reverse-index-vs-size.rb
+++ b/code/array/reverse-index-vs-size.rb
@@ -1,0 +1,17 @@
+require 'benchmark/ips'
+
+ARRAY = [*1..1000]
+
+def slow
+  ARRAY.reverse.index(60)
+end
+
+def fast
+  ARRAY.size - ARRAY.index(60) - 1
+end
+
+Benchmark.ips do |x|
+  x.report('reverse + index') { slow }
+  x.report('size - index - 1')  { fast }
+  x.compare!
+end


### PR DESCRIPTION
The code is a bit uglier and not quite as idiomatic, but I thought the performance improvement may make it work including. The performance gap grows pretty significantly with the size of the array; an array with 100,000,000 items shows the following, for example:

```
Comparison:
              size -:   233724.3 i/s
     reverse + index:        1.3 i/s - 186342.67x slower
```