### PR TITLE
Array#first vs Array#[](0) and Array#last vs Array#(-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,55 @@ Comparison:
  Array#shuffle.first:   304341.1 i/s - 18.82x slower
 ```
 
+#### `Array#first` vs `Array#[](0)` [code](code/array/array_first-vs-index.rb)
+
+```
+$ ruby -v code/array/array-first-vs-index.rb 
+ruby 2.1.1p76 (2014-02-24 revision 45161) [x86_64-linux]
+Calculating -------------------------------------
+fast code description
+                       113.196k i/100ms
+slow code description
+                       115.433k i/100ms
+-------------------------------------------------
+fast code description
+                          6.717M (±20.5%) i/s -     31.808M
+slow code description
+                          5.317M (±21.7%) i/s -     25.164M
+
+Comparison:
+fast code description:  6716503.3 i/s
+slow code description:  5316505.9 i/s - 1.26x slower
+
+```
+
+#### `Array#last` vs `Array#[](-1)` [code](code/array/array_last-vs-index.rb)
+
+
+```
+$ ruby -v code/array/array-last-vs-index.rb 
+ruby 2.1.1p76 (2014-02-24 revision 45161) [x86_64-linux]
+Calculating -------------------------------------
+fast code description
+                    
+
+
+    98.941k i/100ms
+slow code description
+                       124.670k i/100ms
+-------------------------------------------------
+fast code description
+                          6.561M (±17.2%) i/s -     31.562M
+slow code description
+                          5.179M (±13.8%) i/s -     25.308M
+
+Comparison:
+fast code description:  6560852.0 i/s
+slow code description:  5178717.6 i/s - 1.27x slower
+
+
+```
+
 
 ### Enumerable
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Comparison:
  Array#shuffle.first:   304341.1 i/s - 18.82x slower
 ```
 
-#### `Array#first` vs `Array#[](0)` [code](code/array/array_first-vs-index.rb)
+##### `Array#first` vs `Array#[](0)` [code](code/array/array_first-vs-index.rb)
 
 ```
 $ ruby -v code/array/array-first-vs-index.rb 
@@ -180,7 +180,7 @@ slow code description:  5316505.9 i/s - 1.26x slower
 
 ```
 
-#### `Array#last` vs `Array#[](-1)` [code](code/array/array_last-vs-index.rb)
+##### `Array#last` vs `Array#[](-1)` [code](code/array/array_last-vs-index.rb)
 
 
 ```

--- a/code/array/array-first-vs-index.rb
+++ b/code/array/array-first-vs-index.rb
@@ -1,0 +1,17 @@
+require 'benchmark/ips'
+
+ARRAY = [*1..100]
+
+def fast
+    ARRAY[0]
+end
+
+def slow
+    ARRAY.first   
+end
+
+Benchmark.ips do |x|
+      x.report('fast code description') { fast }
+      x.report('slow code description') { slow }
+      x.compare!
+end

--- a/code/array/array-last-vs-index.rb
+++ b/code/array/array-last-vs-index.rb
@@ -1,0 +1,17 @@
+require 'benchmark/ips'
+
+ARRAY = [*1..100]
+
+def fast
+    ARRAY[-1]
+end
+
+def slow
+    ARRAY.last
+end
+
+Benchmark.ips do |x|
+      x.report('fast code description') { fast }
+      x.report('slow code description') { slow }
+      x.compare!
+end


### PR DESCRIPTION
first and last are slower then using index. For example in Rubinius, it returns a new array (Array.new[0, n]) while array[idx] returns a Rubinius.primitive :array_new_range