### PR TITLE
assignment for array elements

### DIFF
--- a/code/general/assignment_array_elements.rb
+++ b/code/general/assignment_array_elements.rb
@@ -1,0 +1,39 @@
+require 'benchmark/ips'
+
+def slow(env)
+  status, headers, body = env
+  headers.delete('Http-Access-Token')
+  [status, headers, body]
+end
+
+def fast(env)
+  env[1].delete('Http-Access-Token')
+  env
+end
+
+env = [200, { 'Http-Access-Token' => '99d25f556b456d658ba0185540d9daa0' }, 'Hello ips']
+
+Benchmark.ips do |x|
+  x.report('element objects Assignment') { slow(env) }
+  x.report('array Assignment') { fast(env) }
+  x.compare!
+end
+
+def slow_ext(env)
+  status, headers, body = env
+  headers['X-Clacks-Overhead'] = 'GNU Terry Pratchett'
+  [status, headers, body]
+end
+
+def fast_ext(env)
+  env[1]['X-Clacks-Overhead'.freeze] = 'GNU Terry Pratchett'.freeze
+  env
+end
+
+env = [200, { 'Http-Access-Token' => '99d25f556b456d658ba0185540d9daa0', 'X-Clacks-Overhead' => 'Cascade' }, 'Hello ips']
+
+Benchmark.ips do |x|
+  x.report('element objects Assignment') { slow_ext(env) }
+  x.report('array Assignment') { fast_ext(env) }
+  x.compare!
+end


### PR DESCRIPTION
Inspired by avoid [run time allocations](https://github.com/wonderbread/rack-pratchett/pull/1)
```
ruby -v code/general/assignment_array_elements.rb
ruby 2.2.1p85 (2015-02-26 revision 49769) [x86_64-darwin14]
Calculating -------------------------------------
element objects Assignment
                        83.252k i/100ms
    array Assignment    81.089k i/100ms
-------------------------------------------------
element objects Assignment
                          2.372M (±10.8%) i/s -     11.739M
    array Assignment      2.875M (± 8.2%) i/s -     14.272M

Comparison:
    array Assignment:  2875123.2 i/s
element objects Assignment:  2371948.5 i/s - 1.21x slower

Calculating -------------------------------------
element objects Assignment
                        81.927k i/100ms
    array Assignment    91.828k i/100ms
-------------------------------------------------
element objects Assignment
                          2.316M (± 8.8%) i/s -     11.552M
    array Assignment      3.801M (±11.8%) i/s -     18.641M

Comparison:
    array Assignment:  3800505.2 i/s
element objects Assignment:  2316031.8 i/s - 1.64x slower
```