### PR TITLE
Hash vs OpenStruct

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,40 @@ Comparison:
 module_eval with string:     1129.7 i/s - 1.19x slower
 ```
 
+##### `hash` vs `openstruct on access` assuming you already have a hash or an openstruct [code](code/general/hash-vs-openstruct-on-access.rb)
+
+```
+$ ruby -v code/general/hash-vs-openstruct-on-access.rb
+ruby-2.1.3 [ x86_64 ]
+Calculating -------------------------------------
+                Hash   145.150k i/100ms
+          OpenStruct   118.906k i/100ms
+-------------------------------------------------
+                Hash      5.545M (± 5.1%) i/s -     27.724M
+          OpenStruct      3.354M (± 1.8%) i/s -     16.766M
+
+Comparison:
+                Hash:  5545294.1 i/s
+          OpenStruct:  3354079.9 i/s - 1.65x slower
+```
+
+##### `hash` vs `openstruct` just creation [code](code/general/hash-vs-openstruct.rb)
+
+```
+$ ruby -v code/general/hash-vs-openstruct.rb
+ruby-2.1.3 [ x86_64 ]
+Calculating -------------------------------------
+                Hash    99.739k i/100ms
+          OpenStruct     9.422k i/100ms
+-------------------------------------------------
+                Hash      2.201M (± 8.6%) i/s -     10.971M
+          OpenStruct    100.191k (± 9.9%) i/s -    499.366k
+
+Comparison:
+                Hash:  2200984.7 i/s
+          OpenStruct:   100190.6 i/s - 21.97x slower
+```
+
 ### Array
 
 ##### `Array#bsearch` vs `Array#find` [code](code/array/bsearch-vs-find.rb)

--- a/code/general/hash-vs-openstruct-on-access.rb
+++ b/code/general/hash-vs-openstruct-on-access.rb
@@ -1,0 +1,19 @@
+require 'benchmark/ips'
+require 'ostruct'
+
+ HASH = {:field_1 => 1, :field_2 => 2}
+ OPENSTRUCT = OpenStruct.new(:field_1 => 1, :field_2 => 2)
+
+def fast
+  [HASH[:field_1], HASH[:field_2]]
+end
+
+def slow
+  [OPENSTRUCT.field_1, OPENSTRUCT.field_2]
+end
+
+Benchmark.ips do |x|
+  x.report("Hash")   { fast }
+  x.report("OpenStruct") { slow }
+  x.compare!
+end

--- a/code/general/hash-vs-openstruct.rb
+++ b/code/general/hash-vs-openstruct.rb
@@ -1,0 +1,16 @@
+require 'benchmark/ips'
+require 'ostruct'
+
+def fast
+  {:field_1 => 1, :field_2 => 2}
+end
+
+def slow
+  OpenStruct.new(:field_1 => 1, :field_2 => 2)
+end
+
+Benchmark.ips do |x|
+  x.report("Hash")   { fast }
+  x.report("OpenStruct") { slow }
+  x.compare!
+end


### PR DESCRIPTION
It's often nicer to reference object instances via properties by using OpenStruct rather than just using a hash. However this shows the price you will pay for it.