### PR TITLE
Add benchmark between array + and concat method

### DIFF
--- a/code/array/array-+-vs-concat.rb
+++ b/code/array/array-+-vs-concat.rb
@@ -1,0 +1,15 @@
+require 'benchmark/ips'
+
+def fast
+  [1, 2, 3] + [4, 5, 6]
+end
+
+def slow
+  [1, 2, 3].concat [4, 5, 6]
+end
+
+Benchmark.ips do |x|
+  x.report("Array#+") { fast }
+  x.report("Array#concat") { slow }
+  x.compare!
+end


### PR DESCRIPTION
Although there is no huge speed difference between Array's + and concat method, the implement is different in ruby. So I write a simple compare and paste the benchmark result here.

```
> ruby -v code/array/array-+-vs-concat.rb
ruby 2.1.4p265 (2014-10-27 revision 48166) [x86_64-darwin14.0]
Calculating -------------------------------------
             Array#+    70.916k i/100ms
        Array#concat    62.433k i/100ms
-------------------------------------------------
             Array#+      1.820M (± 5.5%) i/s -      9.077M
        Array#concat      1.705M (± 6.2%) i/s -      8.491M

Comparison:
             Array#+:  1819615.5 i/s
        Array#concat:  1704666.5 i/s - 1.07x slower
```