### PR TITLE
String#chomp can be faster than String#sub

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,6 +764,25 @@ String#gsub!'string':   481183.5 i/s - 2.52x slower
 String#gsub!/regexp/:   342003.8 i/s - 3.55x slower
 ```
 
+##### `String#sub` vs `String#chomp` [code](code/string/sub-vs-chomp.rb)
+
+Note that this can only be used for removing characters from the end of a string.
+
+```
+$ ruby -v code/string/sub-vs-chomp.rb
+ruby 2.2.2p95 (2015-04-13 revision 50295) [x86_64-darwin13]
+Calculating -------------------------------------
+  String#sub/regexp/    38.068k i/100ms
+String#chomp'string'    78.284k i/100ms
+-------------------------------------------------
+  String#sub/regexp/    560.625k (±17.1%) i/s -      2.703M
+String#chomp'string'      2.704M (±18.6%) i/s -     12.839M
+
+Comparison:
+String#chomp'string':  2703881.6 i/s
+  String#sub/regexp/:   560625.4 i/s - 4.82x slower
+```
+
 ##### `attr_accessor` vs `getter and setter` [code](code/general/attr-accessor-vs-getter-and-setter.rb)
 
 > https://www.omniref.com/ruby/2.2.0/files/method.h?#annotation=4081781&line=47

--- a/code/string/sub-vs-chomp.rb
+++ b/code/string/sub-vs-chomp.rb
@@ -1,0 +1,17 @@
+require 'benchmark/ips'
+
+SLUG = 'YourSubclassType'
+
+def slow
+  SLUG.sub(/Type$/, '')
+end
+
+def fast
+  SLUG.chomp('Type')
+end
+
+Benchmark.ips do |x|
+  x.report('String#sub/regexp/')   { slow }
+  x.report("String#chomp'string'") { fast }
+  x.compare!
+end


### PR DESCRIPTION
Of course only for removing characters from the end of a string. Likewise, `#chomp!` is faster than `#sub!`, although “only” by a factor 2…

Tested with the 4 rubies I have installed:
```
» ruby -v code/string/sub-vs-chomp.rb
ruby 2.2.2p95 (2015-04-13 revision 50295) [x86_64-darwin13]
Calculating -------------------------------------
  String#sub/regexp/    38.068k i/100ms
String#chomp'string'    78.284k i/100ms
-------------------------------------------------
  String#sub/regexp/    560.625k (±17.1%) i/s -      2.703M
String#chomp'string'      2.704M (±18.6%) i/s -     12.839M

Comparison:
String#chomp'string':  2703881.6 i/s
  String#sub/regexp/:   560625.4 i/s - 4.82x slower
```
```
» ruby -v code/string/sub-vs-chomp.rb
ruby 2.1.6p336 (2015-04-13 revision 50298) [x86_64-darwin13.0]
Calculating -------------------------------------
  String#sub/regexp/    45.882k i/100ms
String#chomp'string'    95.599k i/100ms
-------------------------------------------------
  String#sub/regexp/    658.158k (±16.5%) i/s -      3.166M
String#chomp'string'      2.571M (±15.6%) i/s -     12.428M

Comparison:
String#chomp'string':  2571145.8 i/s
  String#sub/regexp/:   658157.7 i/s - 3.91x slower
```
```
» ruby -v code/string/sub-vs-chomp.rb
ruby 2.0.0p576 (2014-09-19) [x86_64-darwin13.4.0]
Calculating -------------------------------------
  String#sub/regexp/     39306 i/100ms
String#chomp'string'     79023 i/100ms
-------------------------------------------------
  String#sub/regexp/   613592.0 (±15.7%) i/s -    2987256 in   5.041570s
String#chomp'string'  2328870.2 (±11.2%) i/s -   11458335 in   5.015344s

Comparison:
String#chomp'string':  2328870.2 i/s
  String#sub/regexp/:   613592.0 i/s - 3.80x slower
```
```
» ruby -v code/string/sub-vs-chomp.rb
ruby 1.9.3p547 (2014-05-14) [x86_64-darwin13.4.0]
Calculating -------------------------------------
  String#sub/regexp/     36128 i/100ms
String#chomp'string'     84940 i/100ms
-------------------------------------------------
  String#sub/regexp/   628335.9 (±21.1%) i/s -    2998624 in   5.058365s
String#chomp'string'  2223420.3 (±19.2%) i/s -   10617500 in   5.018273s

Comparison:
String#chomp'string':  2223420.3 i/s
  String#sub/regexp/:   628335.9 i/s - 3.54x slower
```