### PR TITLE
Fix idiom title

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ Enumerable#sort_by (Symbol#to_proc):    25916.1 i/s
 
 ### Hash
 
-##### `Hash#[]` vs `Hash.fetch` [code](code/hash/bracket-vs-fetch.rb)
+##### `Hash#[]` vs `Hash#fetch` [code](code/hash/bracket-vs-fetch.rb)
 
 If you use Ruby 2.2, `Symbol` could be more performant than `String` as `Hash` keys.
 Read more regarding this: [Symbol GC in Ruby 2.2](http://www.sitepoint.com/symbol-gc-ruby-2-2/) and [Unraveling String Key Performance in Ruby 2.2](http://www.sitepoint.com/unraveling-string-key-performance-ruby-2-2/).
@@ -438,7 +438,7 @@ Comparison:
   Hash#fetch, string:  3981166.5 i/s - 1.89x slower
 ```
 
-##### `Hash#[]` vs `Hash#dup` [code](code/hash/bracket-vs-dup.rb)
+##### `Hash[]` vs `Hash#dup` [code](code/hash/bracket-vs-dup.rb)
 
 Source: http://tenderlovemaking.com/2015/02/11/weird-stuff-with-hashes.html
 


### PR DESCRIPTION
I think ... :rabbit: 

* `Hash.fetch` -> `Hash#fetch`
* `Hash#[]` -> `Hash[]` on bracket-vs-dup