### PR TITLE
Add Function with single Array argument vs splat arguments example

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,28 @@ Comparison:
              &method:   467095.4 i/s - 4.00x slower
 ```
 
+##### Function with single Array argument vs splat arguments [code](code/general/array-argument-vs-splat-arguments.rb)
+
+```
+$ ruby -v array-argument-vs-splat-argument.rb
+ruby 2.1.7p400 (2015-08-18 revision 51632) [x86_64-linux-gnu]
+Calculating -------------------------------------
+Function with single Array argument
+                       157.231k i/100ms
+Function with splat arguments
+                         4.983k i/100ms
+-------------------------------------------------
+Function with single Array argument
+                          5.581M (± 2.0%) i/s -     27.987M
+Function with splat arguments
+                         54.428k (± 3.3%) i/s -    274.065k
+
+Comparison:
+Function with single Array argument:  5580972.6 i/s
+Function with splat arguments:    54427.7 i/s - 102.54x slower
+
+```
+
 ### Array
 
 ##### `Array#bsearch` vs `Array#find` [code](code/array/bsearch-vs-find.rb)

--- a/code/general/array-argument-vs-splat-arguments.rb
+++ b/code/general/array-argument-vs-splat-arguments.rb
@@ -1,0 +1,22 @@
+require "benchmark/ips"
+
+module M
+  ITEMS = (1..10000).to_a.freeze
+
+  def self.func(*args)
+  end
+end
+
+def fast
+  M.func(M::ITEMS)
+end
+
+def slow
+  M.func(*M::ITEMS)
+end
+
+Benchmark.ips do |x|
+  x.report("Function with single Array argument") { fast }
+  x.report("Function with splat arguments") { slow }
+  x.compare!
+end


### PR DESCRIPTION
Invoking a function that expects multiple splat arguments when all you have is an Array is quite costly (100x). Also, it won't work with sufficiently large arrays as seen [here](http://stackoverflow.com/questions/28703587/systemstackerror-when-pushing-more-than-130798-objects-into-an-array).