### PR TITLE
Block vs Proc.new

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,6 +656,23 @@ Comparison:
           block.call:  1068741.4 i/s - 3.82x slower
 ```
 
+##### `$block` vs `Proc.new` [code](code/proc-and-block/block-vs-proc-new.rb)
+
+```
+$ ruby -v code/proc-and-block/block-vs-proc-new.rb
+ruby 2.2.3p173 (2015-08-18 revision 51636) [x86_64-darwin15]
+Calculating -------------------------------------
+              &block    78.665k i/100ms
+            Proc.new    68.469k i/100ms
+-------------------------------------------------
+              &block      1.496M (±15.2%) i/s -      7.237M
+            Proc.new      1.308M (±18.1%) i/s -      6.162M
+
+Comparison:
+              &block:  1496458.2 i/s
+            Proc.new:  1308439.7 i/s - 1.14x slower
+
+```
 
 ### String
 

--- a/code/proc-and-block/block-vs-proc-new.rb
+++ b/code/proc-and-block/block-vs-proc-new.rb
@@ -1,0 +1,16 @@
+require 'benchmark/ips'
+
+def slow &block
+  block
+end
+
+def slow2
+  Proc.new
+end
+
+
+Benchmark.ips do |x|
+  x.report("&block") { slow { 1 + 1 } }
+  x.report("Proc.new") { slow2 { 1 + 1 } }
+  x.compare!
+end


### PR DESCRIPTION
There are two ways to access block argument, one is using `&block`.

``` ruby
def test(&block)
  block
end
```

Another is using `Proc.new` inside the method.

``` ruby
def test
  Proc.new
end
```

And the benchmark result was

```
ruby 2.2.3p173 (2015-08-18 revision 51636) [x86_64-darwin15]
Calculating -------------------------------------
              &block    79.766k i/100ms
            Proc.new    76.432k i/100ms
-------------------------------------------------
              &block      1.601M (± 5.5%) i/s -      8.056M
            Proc.new      1.486M (± 4.5%) i/s -      7.414M

Comparison:
              &block:  1601064.1 i/s
            Proc.new:  1486080.7 i/s - 1.08x slower
```
