### PR TITLE
Array insert vs unshift

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,22 @@ Comparison:
           Array#last:  7639254.5 i/s - 1.12x slower
 ```
 
+##### `Array#insert` vs `Array#unshift` [code](code/array/insert-vs-unshift.rb)
+
+```
+$ ruby -v code/array/insert-vs-unshift.rb
+ruby 2.2.0p0 (2014-12-25 revision 49005) [x86_64-darwin10.0]
+Calculating -------------------------------------
+       Array#unshift     4.000  i/100ms
+        Array#insert     1.000  i/100ms
+-------------------------------------------------
+       Array#unshift     44.947  (± 6.7%) i/s -    224.000
+        Array#insert      0.171  (± 0.0%) i/s -      1.000  in   5.841595s
+
+Comparison:
+       Array#unshift:       44.9 i/s
+        Array#insert:        0.2 i/s - 262.56x slower
+```
 
 ### Enumerable
 

--- a/code/array/insert-vs-unshift.rb
+++ b/code/array/insert-vs-unshift.rb
@@ -1,0 +1,15 @@
+require 'benchmark/ips'
+
+Benchmark.ips do |x|
+  x.report('Array#unshift') do
+    array = []
+    100_000.times { |i| array.unshift(i) }
+  end
+
+  x.report('Array#insert') do
+    array = []
+    100_000.times { |i| array.insert(0, i) }
+  end
+
+  x.compare!
+end


### PR DESCRIPTION
I needed to insert items in the beginning of the array and unshift turns out to be much faster. The comparison here is for a larger array and insert of the beginning of the same array. Initially i did the comparison between `fast` and `slow`, but this does not reflect correctly the difference in the performance.

````ruby
def fast
  [].unshift(1)
end

def slow
  [].insert(0, 1)
end
````

Let me know if further information is required.