### PR TITLE
Immutable vs Mutable strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -938,15 +938,15 @@ Comparison:
 $ ruby -v code/string/mutable_vs_immutable_strings.rb
 ruby 2.2.1p85 (2015-02-26 revision 49769) [x86_64-darwin14]
 Warming up --------------------------------------
-              freeze   111.292k i/100ms
-              normal   106.928k i/100ms
+      Without Freeze   106.961k i/100ms
+         With Freeze   118.210k i/100ms
 Calculating -------------------------------------
-              freeze      5.282M (±14.2%) i/s -     25.931M
-              normal      4.549M (±14.3%) i/s -     22.348M
+      Without Freeze      4.386M (± 6.1%) i/s -     21.927M
+         With Freeze      6.893M (± 6.9%) i/s -     34.281M
 
 Comparison:
-              freeze:  5281661.4 i/s
-              normal:  4548975.9 i/s - same-ish: difference falls within error
+         With Freeze:  6892639.5 i/s
+      Without Freeze:  4386460.4 i/s - 1.57x slower
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -932,6 +932,24 @@ Comparison:
          String#gsub:   516604.2 i/s - 3.60x slower
 ```
 
+##### `Mutable` vs `Immutable` [code](code/string/mutable_vs_immutable_strings.rb)
+
+```
+$ ruby -v code/string/mutable_vs_immutable_strings.rb
+ruby 2.2.1p85 (2015-02-26 revision 49769) [x86_64-darwin14]
+Warming up --------------------------------------
+              freeze   111.292k i/100ms
+              normal   106.928k i/100ms
+Calculating -------------------------------------
+              freeze      5.282M (±14.2%) i/s -     25.931M
+              normal      4.549M (±14.3%) i/s -     22.348M
+
+Comparison:
+              freeze:  5281661.4 i/s
+              normal:  4548975.9 i/s - same-ish: difference falls within error
+```
+
+
 ##### `String#sub!` vs `String#gsub!` vs `String#[]=` [code](code/string/sub!-vs-gsub!-vs-[]=.rb)
 
 Note that `String#[]` will throw an `IndexError` when given string or regexp not matched.

--- a/code/string/mutable_vs_immutable_strings.rb
+++ b/code/string/mutable_vs_immutable_strings.rb
@@ -1,0 +1,12 @@
+require 'benchmark/ips'
+
+IMMUTABLE_TEST = "writing_fast_ruby".freeze
+mutable_test = "writing_fast_ruby"
+
+hash = {"writing_fast_ruby" => "is_cool"}
+
+Benchmark.ips do |x|
+  x.report("freeze") { hash[IMMUTABLE_TEST] }
+  x.report("normal") { hash[mutable_test] }
+  x.compare!
+end

--- a/code/string/mutable_vs_immutable_strings.rb
+++ b/code/string/mutable_vs_immutable_strings.rb
@@ -1,12 +1,17 @@
 require 'benchmark/ips'
 
-IMMUTABLE_TEST = "writing_fast_ruby".freeze
-mutable_test = "writing_fast_ruby"
+# Allocates new string over and over again
+def without_freeze
+  "To freeze or not to freeze"
+end
 
-hash = {"writing_fast_ruby" => "is_cool"}
+# Keeps and reuses shared string
+def with_feeze
+  "To freeze or not to freeze".freeze
+end
 
 Benchmark.ips do |x|
-  x.report("freeze") { hash[IMMUTABLE_TEST] }
-  x.report("normal") { hash[mutable_test] }
+  x.report("Without Freeze") { without_freeze }
+  x.report("With Freeze") { with_feeze }
   x.compare!
 end


### PR DESCRIPTION
Using 'freeze' increases performances for strings.

```
In Ruby 2.1, "str".freeze is optimized by the compiler to return a single shared frozen strings on every invocation. An alternative "str"f syntax was implemented initially, but later reverted.

Although the external scope of this feature is limited, internally it is used extensively to de-duplicate strings in the VM. Previously, every def method_missing(), the symbol :method_missing and any literal "method_missing" strings in the code-base would all create their own String objects. With Ruby 2.1, only one string is created and shared. Since many strings are commonly re-used in any given code base, this easily adds up. In fact, large applications can expect up to 30% fewer long-lived strings on their heaps in 2.1.

For 2.2, there are plans to expose this feature via a new String#f. There's also a proposal for a magic immutable: string comment to make frozen strings default for a given file.
```

Source: http://tmm1.net/ruby21-fstrings/