### PR TITLE
Update gsub-vs-tr.rb

### DIFF
--- a/code/string/gsub-vs-tr.rb
+++ b/code/string/gsub-vs-tr.rb
@@ -1,3 +1,4 @@
+# gem install 'benchmark-ips'
 require 'benchmark/ips'
 
 SLUG = 'writing-fast-ruby'


### PR DESCRIPTION
took me a while to figure out that that's not part of core  `ruby` `benchmark` lib