### PR TITLE
unintentional object allocation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'benchmark-ips', '>= 2.0'
-
+gem 'benchmark-memory'
 gem 'rake'

--- a/code/method/default-arguments.rb
+++ b/code/method/default-arguments.rb
@@ -1,0 +1,20 @@
+require 'benchmark/memory'
+
+EM_HASH = {}.freeze
+
+def test_hash(a={}); end
+def test_hash2(a=EM_HASH); end
+
+def fast
+  10_000.times{ test_hash2 }
+end
+
+def slow
+  10_000.times{ test_hash }
+end
+
+Benchmark.memory do |x|
+  x.report('constant as default argument  ') { fast }
+  x.report('new object as default argument') { slow }
+  x.compare!
+end


### PR DESCRIPTION
```
ruby code/method/default-arguments.rb
Calculating -------------------------------------
constant as default argument
                         0.000  memsize (     0.000  retained)
                         0.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
new object as default argument
                       400.000k memsize (     0.000  retained)
                        10.000k objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
constant as default argument  :          0 allocated
new object as default argument:     400000 allocated - Infx more
```