### PR TITLE
Add test for `ARRAY.inject(:+)` vs `ARRAY.sum`

### DIFF
--- a/code/enumerable/inject-symbol-plus-vs-sum.rb
+++ b/code/enumerable/inject-symbol-plus-vs-sum.rb
@@ -1,0 +1,19 @@
+require "rubygems"
+require "benchmark/ips"
+
+ARRAY = (1..1000).to_a
+
+def fast
+  ARRAY.sum
+end
+
+def slow
+  ARRAY.inject(:+)
+end
+
+Benchmark.ips do |x|
+  x.report('sum')                { fast }
+  x.report('inject symbol plus') { slow }
+
+  x.compare!
+end


### PR DESCRIPTION
I was curious to see the difference between the `sum` method in enumerables, which was introduced in Ruby 2.4, and the commonly used `inject(:+)`. For me `inject(:+)` is a little bit slower (1.02x).

This PR cannot be merged immediately as it will break for Ruby < 2.4. Do you have a way to only run tests for supported versions of Ruby?