### PR TITLE
Update `Proc#call` and block arguments vs `yield` for Ruby 2.5 and 2.6

### DIFF
--- a/code/proc-and-block/proc-call-vs-yield.rb
+++ b/code/proc-and-block/proc-call-vs-yield.rb
@@ -19,7 +19,7 @@ end
 Benchmark.ips do |x|
   x.report('block.call') { slow { 1 + 1 } }
   x.report('block + yield') { slow2 { 1 + 1 } }
-  x.report('block argument') { slow3 { 1 + 1 } }
+  x.report('unused block') { slow3 { 1 + 1 } }
   x.report('yield')      { fast { 1 + 1 } }
   x.compare!
 end


### PR DESCRIPTION
In Ruby 2.5, passing through a `block` argument has become a lot faster.

I renamed the 'block argument' benchmark because I felt the old name was misleading as the fastest on Ruby 2.5.