### PR TITLE
Update some examples with Ruby 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,17 +663,17 @@ When expecting well-formatted data from e.g. an API, `iso8601` is faster and wil
 
 ```
 $ ruby -v code/date/iso8601-vs-parse.rb
-ruby 2.4.3p205 (2017-12-14 revision 61247) [x86_64-darwin17]
+ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-darwin19]
 Warming up --------------------------------------
-        Date.iso8601    28.880k i/100ms
-          Date.parse    15.805k i/100ms
+        Date.iso8601    33.733k i/100ms
+          Date.parse    18.122k i/100ms
 Calculating -------------------------------------
-        Date.iso8601    328.035k (± 4.7%) i/s -      1.646M in   5.029287s
-          Date.parse    175.546k (± 3.8%) i/s -    885.080k in   5.049444s
+        Date.iso8601    403.207k (± 2.2%) i/s -      2.024M in   5.022088s
+          Date.parse    203.007k (± 1.5%) i/s -      1.015M in   5.000242s
 
 Comparison:
-        Date.iso8601:   328035.3 i/s
-          Date.parse:   175545.9 i/s - 1.87x  slower
+        Date.iso8601:   403206.7 i/s
+          Date.parse:   203006.5 i/s - 1.99x  slower
 ```
 
 ### Hash

--- a/README.md
+++ b/README.md
@@ -1236,33 +1236,36 @@ String#dup["string"]=:   917873.1 i/s
 
 ```
 $ ruby -v code/string/gsub-vs-tr.rb
-ruby 2.2.0p0 (2014-12-25 revision 49005) [x86_64-darwin14]
+ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-darwin19]
 
+Warming up --------------------------------------
+         String#gsub    53.060k i/100ms
+           String#tr   175.023k i/100ms
 Calculating -------------------------------------
-         String#gsub    38.268k i/100ms
-           String#tr    83.210k i/100ms
--------------------------------------------------
-         String#gsub    516.604k (± 4.4%) i/s -      2.602M
-           String#tr      1.862M (± 4.0%) i/s -      9.320M
+         String#gsub    584.292k (± 4.5%) i/s -      2.918M in   5.005139s
+           String#tr      3.071M (± 5.6%) i/s -     15.402M in   5.033238s
 
 Comparison:
-           String#tr:  1861860.4 i/s
-         String#gsub:   516604.2 i/s - 3.60x slower
+           String#tr:  3070572.5 i/s
+         String#gsub:   584292.4 i/s - 5.26x  slower
+
 ```
 
 ##### `Mutable` vs `Immutable` [code](code/string/mutable_vs_immutable_strings.rb)
 
 ```
 $ ruby -v code/string/mutable_vs_immutable_strings.rb
-ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin14]
-
+ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-darwin19]
+Warming up --------------------------------------
+      Without Freeze   305.218k i/100ms
+         With Freeze   340.241k i/100ms
 Calculating -------------------------------------
-      Without Freeze      7.279M (± 6.6%) i/s -     36.451M in   5.029785s
-         With Freeze      9.329M (± 7.9%) i/s -     46.370M in   5.001345s
+      Without Freeze     10.683M (± 2.7%) i/s -     53.413M in   5.003759s
+         With Freeze     14.946M (± 3.8%) i/s -     74.853M in   5.015808s
 
 Comparison:
-         With Freeze:  9329054.3 i/s
-      Without Freeze:  7279203.1 i/s - 1.28x slower
+         With Freeze: 14946436.7 i/s
+      Without Freeze: 10683192.9 i/s - 1.40x  slower
 ```
 
 

--- a/code/date/iso8601-vs-parse.rb
+++ b/code/date/iso8601-vs-parse.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 require 'benchmark/ips'
 require 'date'
 
-STRING = '2018-03-21'.freeze
+STRING = '2018-03-21'
 
 def fast
   Date.iso8601(STRING)


### PR DESCRIPTION
Now that Ruby 2.7 is out I've updated the date.parse vs date.iso8601 example, strings tr vs gsub and mutable vs immutable strings example.
Happy to update more examples if this one goes forward.
Ran on a MacBook Pro (Retina, 15-inch, Mid 2015), 2.2 GHz Intel Core i7, 16 GB 1600 MHz DDR3