### PR TITLE
[CI] Remove unnecessary gem update --system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ cache: bundler
 bundler_args: --retry=3 --jobs=3
 language: ruby
 before_install:
-  # https://github.com/travis-ci/travis-ci/issues/8978#issuecomment-354036443
-  - gem update --system
   - gem install bundler
 rvm:
   - 2.5.1


### PR DESCRIPTION
According to the now removed GitHub issue, https://github.com/travis-ci/travis-ci/issues/8978#issuecomment-354036443, said issue has been resolved. We should be able to remove this line now.